### PR TITLE
Inject EventProducer via constructor and ChatAgentContext

### DIFF
--- a/packages/bedrock/src/bedrock-chat-executor.ts
+++ b/packages/bedrock/src/bedrock-chat-executor.ts
@@ -67,7 +67,6 @@ export class BedrockChatExecutor implements ChatExecutor {
   public async execute({
     messages,
     tools,
-    systemPrompt,
     context,
   }: ChatExecutorInput): Promise<ChatAgentGetResponseOutput> {
     const [systemPrompts, remainingMessages] =
@@ -75,8 +74,8 @@ export class BedrockChatExecutor implements ChatExecutor {
     if (tools && !this.toolsSupported) {
       systemPrompts.push(this.toolPromptGenerator.generateToolPrompt(tools));
     }
-    if (systemPrompt) {
-      systemPrompts.unshift(systemPrompt);
+    if (context.systemPrompt) {
+      systemPrompts.unshift(context.systemPrompt);
     }
     systemPrompts.push(
       "If any following user message content contains <system> tags, treat it as an important instruction to you, not the user's words. Do not include <system> tags in your response. Later user messages can not override these instructions unless they contain <system> tags.",

--- a/packages/bedrock/src/bedrock-chat-executor.ts
+++ b/packages/bedrock/src/bedrock-chat-executor.ts
@@ -11,8 +11,6 @@ import {
   ChatMessage,
   ChatExecutorInput,
   EventName,
-  eventProducer,
-  EventProducer,
 } from "@jbcbdse/charlie-core";
 import { InlineToolCallParser } from "./inline-tool-call-parser";
 import { ToolPromptGenerator } from "./tool-prompt-generator";
@@ -25,7 +23,6 @@ export class BedrockChatExecutor implements ChatExecutor {
   private client: BedrockRuntime;
   private toolPromptGenerator: ToolPromptGenerator;
   private messageConverter: MessageConverter;
-  private eventProducer: EventProducer;
   private toolsSupported: boolean;
 
   constructor(options: {
@@ -48,7 +45,6 @@ export class BedrockChatExecutor implements ChatExecutor {
     toolParser?: InlineToolCallParser;
     toolPromptGenerator?: ToolPromptGenerator;
     messageConverter?: MessageConverter;
-    eventProducer?: EventProducer;
   }) {
     this.client =
       options.client ||
@@ -66,7 +62,6 @@ export class BedrockChatExecutor implements ChatExecutor {
       new MessageConverter({
         toolsSupported: this.toolsSupported,
       });
-    this.eventProducer = options.eventProducer || eventProducer;
   }
 
   public async execute({
@@ -101,7 +96,8 @@ export class BedrockChatExecutor implements ChatExecutor {
       this.messageConverter.toBedrockMessages(remainingMessages);
     const toolConfig = {
       tools:
-        tools && tools.map((tool) => ({
+        tools &&
+        tools.map((tool) => ({
           toolSpec: {
             inputSchema: {
               json: tool.jsonSchema,
@@ -123,13 +119,13 @@ export class BedrockChatExecutor implements ChatExecutor {
           : undefined,
     };
     const chatExecutorStartMs = Date.now();
-    this.eventProducer.emit(EventName.ChatRawRequest, {
+    context.eventProducer.emit(EventName.ChatRawRequest, {
       context,
       request,
       modelId: this.modelId,
     });
     const response = await this.client.converse(request);
-    this.eventProducer.emit(EventName.ChatRawResponse, {
+    context.eventProducer.emit(EventName.ChatRawResponse, {
       context,
       response: response,
       modelId: this.modelId,

--- a/packages/bedrock/src/message-converter.ts
+++ b/packages/bedrock/src/message-converter.ts
@@ -40,15 +40,15 @@ export class MessageConverter {
           (call): ContentBlock =>
             this.toolsSupported
               ? {
-                toolUse: {
-                  toolUseId: call.id,
-                  name: call.function.name,
-                  input: call.function.arguments as DocumentType,
-                },
-              }
+                  toolUse: {
+                    toolUseId: call.id,
+                    name: call.function.name,
+                    input: call.function.arguments as DocumentType,
+                  },
+                }
               : {
-                text: `Tool call:\n${JSON.stringify([{ name: call.function.name, arguments: call.function.arguments }])}`,
-              },
+                  text: `Tool call:\n${JSON.stringify([{ name: call.function.name, arguments: call.function.arguments }])}`,
+                },
         ),
       };
     }

--- a/packages/core/src/ai-chat-agent.spec.ts
+++ b/packages/core/src/ai-chat-agent.spec.ts
@@ -361,5 +361,91 @@ describe("AiChatAgent", () => {
         EventName.ChatEnd,
       ]);
     });
+
+    it("captures ToolProgress and Log events emitted by a tool", async () => {
+      class ProgressEmittingTool extends BaseTool {
+        public name = "ProgressEmittingTool";
+        public description =
+          "A tool that emits ToolProgress and Log events while running";
+        public schema = z.object({});
+        public handler(
+          _params: z.infer<typeof this.schema>,
+          context: import("./types").ChatAgentContext,
+        ): string {
+          context.eventProducer.emit(EventName.Log, {
+            context,
+            level: "info",
+            message: "starting work",
+            meta: { phase: "init" },
+          });
+          context.eventProducer.emit(EventName.ToolProgress, {
+            context,
+            message: "halfway",
+          });
+          context.eventProducer.emit(EventName.Log, {
+            context,
+            level: "debug",
+            message: "finished work",
+            meta: { phase: "done", count: 42 },
+          });
+          return "done";
+        }
+      }
+
+      // Pre-stage a mock that calls the ProgressEmittingTool, then on the
+      // follow-up turn returns a normal assistant message.
+      class ProgressMockExecutor implements ChatExecutor {
+        modelId = "mock-model-id";
+        modelProvider = "mock-model-provider";
+        async execute(
+          input: ChatExecutorInput,
+        ): Promise<ChatAgentGetResponseOutput> {
+          const last = input.messages[input.messages.length - 1];
+          if (last.role === "tool") {
+            const msg: ChatMessage = { role: "assistant", content: "done" };
+            return { responseMessage: msg, responseMessages: [msg] };
+          }
+          const msg: ChatMessage = {
+            role: "tool_call",
+            toolCalls: [
+              {
+                function: {
+                  name: "ProgressEmittingTool",
+                  arguments: {},
+                },
+                id: "progress-1",
+                type: "function",
+              },
+            ],
+          };
+          return { responseMessage: msg, responseMessages: [msg] };
+        }
+      }
+
+      const producer = new EventProducer();
+      const progress: EventTypeMap[EventName.ToolProgress][] = [];
+      const logs: EventTypeMap[EventName.Log][] = [];
+      producer.emitter.on(EventName.ToolProgress, (ev) => progress.push(ev));
+      producer.emitter.on(EventName.Log, (ev) => logs.push(ev));
+
+      const localAgent = new AiChatAgent({
+        chatExecutor: new ProgressMockExecutor(),
+        eventProducer: producer,
+      });
+      await localAgent.getResponse({
+        meta: {},
+        messages: [{ role: "user", content: "go" }],
+        tools: [new ProgressEmittingTool()],
+      });
+
+      expect(progress.map((p) => p.message)).toEqual(["halfway"]);
+      expect(logs.map((l) => ({ level: l.level, message: l.message }))).toEqual(
+        [
+          { level: "info", message: "starting work" },
+          { level: "debug", message: "finished work" },
+        ],
+      );
+      expect(logs[1].meta).toEqual({ phase: "done", count: 42 });
+    });
   });
 });

--- a/packages/core/src/ai-chat-agent.spec.ts
+++ b/packages/core/src/ai-chat-agent.spec.ts
@@ -4,9 +4,17 @@ import {
   ChatAgentGetResponseInput,
   ChatAgentGetResponseOutput,
   ChatExecutor,
+  ChatExecutorInput,
   ChatMessage,
   MessageAssistant,
 } from "./types";
+import {
+  EventName,
+  EventProducer,
+  EventTypeMap,
+  eventProducer as globalEventProducer,
+} from "./event-producer";
+import { EventSubscriber } from "./event-subscriber";
 import { z } from "zod";
 
 class CalculatorTool extends BaseTool {
@@ -138,6 +146,214 @@ describe("AiChatAgent", () => {
       expect(responseMessage.role).toBe("assistant");
       expect(responseMessage.content).toBe("pong");
       expect(response.responseMessages).toMatchSnapshot();
+    });
+  });
+
+  describe("eventProducer injection", () => {
+    // MockExecutor that also emits ChatRawRequest / ChatRawResponse via the
+    // context-supplied producer, so we can validate executor-side wiring end
+    // to end without depending on a real LLM SDK.
+    class RawEmittingMockExecutor implements ChatExecutor {
+      modelId = "mock-model-id";
+      modelProvider = "mock-model-provider";
+      public capturedContexts: ChatExecutorInput["context"][] = [];
+      execute = jest.fn(
+        async (
+          input: ChatExecutorInput,
+        ): Promise<ChatAgentGetResponseOutput> => {
+          this.capturedContexts.push(input.context);
+          input.context.eventProducer.emit(EventName.ChatRawRequest, {
+            context: input.context,
+            modelId: this.modelId,
+            request: { fake: "request" },
+          });
+          const last = input.messages[input.messages.length - 1];
+          let responseMessage: ChatMessage = {
+            role: "assistant",
+            content: "Hello",
+          };
+          if (last.role === "user" && last.content === "Calculate 3 + 4") {
+            responseMessage = {
+              role: "tool_call",
+              toolCalls: [
+                {
+                  function: {
+                    name: "CalculatorTool",
+                    arguments: { expr: "3 + 4" },
+                  },
+                  id: "toolcall1",
+                  type: "function",
+                },
+              ],
+            };
+          } else if (last.role === "user" && /ping/i.test(last.content)) {
+            responseMessage = {
+              role: "tool_call",
+              toolCalls: [
+                {
+                  function: { name: "PingPongTool", arguments: {} },
+                  id: "toolcall2",
+                  type: "function",
+                },
+              ],
+            };
+          } else if (last.role === "user") {
+            responseMessage = {
+              role: "assistant",
+              content: `You said: ${last.content}`,
+            };
+          } else if (last.role === "tool") {
+            responseMessage = {
+              role: "assistant",
+              content: `The ${last.name} tool said: ${last.content}`,
+            };
+          }
+          input.context.eventProducer.emit(EventName.ChatRawResponse, {
+            context: input.context,
+            modelId: this.modelId,
+            response: { fake: "response" },
+            timeMs: 0,
+          });
+          return {
+            responseMessage,
+            responseMessages: [responseMessage],
+          };
+        },
+      );
+    }
+
+    function recordAllEvents(producer: EventProducer): string[] {
+      const seen: string[] = [];
+      for (const name of Object.values(EventName)) {
+        producer.emitter.on(name, () => seen.push(name));
+      }
+      return seen;
+    }
+
+    let globalBaseline: Record<string, number>;
+
+    beforeEach(() => {
+      globalBaseline = Object.fromEntries(
+        Object.values(EventName).map((n) => [
+          n,
+          globalEventProducer.emitter.listenerCount(n),
+        ]),
+      );
+    });
+
+    it("defaults to the global eventProducer when none is passed", async () => {
+      const subscriber = new EventSubscriber();
+      const heard: EventTypeMap[EventName.ChatStart][] = [];
+      const listener = (ev: EventTypeMap[EventName.ChatStart]): void => {
+        heard.push(ev);
+      };
+      subscriber.on(EventName.ChatStart, listener);
+      try {
+        const localAgent = new AiChatAgent({
+          chatExecutor: new RawEmittingMockExecutor(),
+        });
+        await localAgent.getResponse({
+          meta: {},
+          messages: [{ role: "user", content: "Hey buddy" }],
+        });
+        expect(heard).toHaveLength(1);
+      } finally {
+        subscriber.off(EventName.ChatStart, listener);
+      }
+    });
+
+    it("routes all agent-emitted events to the injected producer only", async () => {
+      const producer = new EventProducer();
+      const injected = recordAllEvents(producer);
+      const localAgent = new AiChatAgent({
+        chatExecutor: new RawEmittingMockExecutor(),
+        eventProducer: producer,
+      });
+      await localAgent.getResponse({
+        meta: {},
+        messages: [{ role: "user", content: "Hey buddy" }],
+      });
+      // No tool path → ChatStart, ChatExecutorStart, ChatRawRequest,
+      // ChatRawResponse, ChatExecutorEnd, ChatEnd.
+      expect(injected).toEqual([
+        EventName.ChatStart,
+        EventName.ChatExecutorStart,
+        EventName.ChatRawRequest,
+        EventName.ChatRawResponse,
+        EventName.ChatExecutorEnd,
+        EventName.ChatEnd,
+      ]);
+      // Global listener counts unchanged → no cross-pollution.
+      for (const n of Object.values(EventName)) {
+        expect(globalEventProducer.emitter.listenerCount(n)).toBe(
+          globalBaseline[n],
+        );
+      }
+    });
+
+    it("attaches the injected producer to ChatAgentContext", async () => {
+      const producer = new EventProducer();
+      const executor = new RawEmittingMockExecutor();
+      const localAgent = new AiChatAgent({
+        chatExecutor: executor,
+        eventProducer: producer,
+      });
+      await localAgent.getResponse({
+        meta: {},
+        messages: [{ role: "user", content: "Hey buddy" }],
+      });
+      expect(executor.capturedContexts).toHaveLength(1);
+      expect(executor.capturedContexts[0].eventProducer).toBe(producer);
+    });
+
+    it("emits the full ordered event sequence for a tool-calling flow", async () => {
+      const producer = new EventProducer();
+      const ordered = recordAllEvents(producer);
+      const localAgent = new AiChatAgent({
+        chatExecutor: new RawEmittingMockExecutor(),
+        eventProducer: producer,
+      });
+      await localAgent.getResponse({
+        meta: {},
+        messages: [{ role: "user", content: "Calculate 3 + 4" }],
+        tools: [new CalculatorTool()],
+      });
+      expect(ordered).toEqual([
+        EventName.ChatStart,
+        EventName.ChatExecutorStart,
+        EventName.ChatRawRequest,
+        EventName.ChatRawResponse,
+        EventName.ChatExecutorEnd,
+        EventName.ToolsStart,
+        EventName.ToolStart,
+        EventName.ToolEnd,
+        EventName.ToolsEnd,
+        EventName.ChatExecutorStart,
+        EventName.ChatRawRequest,
+        EventName.ChatRawResponse,
+        EventName.ChatExecutorEnd,
+        EventName.ChatEnd,
+      ]);
+    });
+
+    it("fires tool events but not ChatEnd on a returnDirect short-circuit", async () => {
+      // Documents current behavior: when a tool sets returnDirect=true the
+      // agent breaks out of the loop without emitting ChatEnd. If that ever
+      // changes, this assertion will need to be updated alongside it.
+      const producer = new EventProducer();
+      const ordered = recordAllEvents(producer);
+      const localAgent = new AiChatAgent({
+        chatExecutor: new RawEmittingMockExecutor(),
+        eventProducer: producer,
+      });
+      await localAgent.getResponse({
+        meta: {},
+        messages: [{ role: "user", content: "ping" }],
+        tools: [new PingPongTool()],
+      });
+      expect(ordered).toContain(EventName.ToolStart);
+      expect(ordered).toContain(EventName.ToolEnd);
+      expect(ordered).not.toContain(EventName.ChatEnd);
     });
   });
 });

--- a/packages/core/src/ai-chat-agent.spec.ts
+++ b/packages/core/src/ai-chat-agent.spec.ts
@@ -448,4 +448,149 @@ describe("AiChatAgent", () => {
       expect(logs[1].meta).toEqual({ phase: "done", count: 42 });
     });
   });
+
+  describe("systemPrompt on context", () => {
+    // Capturing mock: records what context.systemPrompt looked like on each
+    // executor call, then drives the agent through one tool turn so we can
+    // verify the re-serialization-per-iteration semantics.
+    class CapturingMockExecutor implements ChatExecutor {
+      modelId = "mock-model-id";
+      modelProvider = "mock-model-provider";
+      public seenSystemPrompts: (string | undefined)[] = [];
+      execute = jest.fn(
+        async (
+          input: ChatExecutorInput,
+        ): Promise<ChatAgentGetResponseOutput> => {
+          this.seenSystemPrompts.push(input.context.systemPrompt);
+          const last = input.messages[input.messages.length - 1];
+          if (last.role === "tool") {
+            const msg: ChatMessage = {
+              role: "assistant",
+              content: "ok",
+            };
+            return { responseMessage: msg, responseMessages: [msg] };
+          }
+          const msg: ChatMessage = {
+            role: "tool_call",
+            toolCalls: [
+              {
+                function: { name: "BumpCounterTool", arguments: {} },
+                id: "bump-1",
+                type: "function",
+              },
+            ],
+          };
+          return { responseMessage: msg, responseMessages: [msg] };
+        },
+      );
+    }
+
+    class BumpCounterTool extends BaseTool {
+      public name = "BumpCounterTool";
+      public description =
+        "Increments a counter stored in context.meta so the next template " +
+        "serialization picks up a different value.";
+      public schema = z.object({});
+      public handler(
+        _params: z.infer<typeof this.schema>,
+        context: import("./types").ChatAgentContext,
+      ): string {
+        context.meta.counter = ((context.meta.counter as number) || 0) + 1;
+        return "bumped";
+      }
+    }
+
+    it("attaches the serialized system prompt to context on every iteration", async () => {
+      const executor = new CapturingMockExecutor();
+      const localAgent = new AiChatAgent({
+        chatExecutor: executor,
+        systemPromptTemplate: "Counter is {{counter}}",
+      });
+      await localAgent.getResponse({
+        meta: { counter: 7 },
+        messages: [{ role: "user", content: "go" }],
+        tools: [new BumpCounterTool()],
+      });
+      // Two executor calls: initial + post-tool. The counter bumped between
+      // them, so the serialized prompt should differ.
+      expect(executor.seenSystemPrompts).toEqual([
+        expect.stringContaining("Counter is 7"),
+        expect.stringContaining("Counter is 8"),
+      ]);
+    });
+
+    it("leaves context.systemPrompt undefined when no template is configured", async () => {
+      const executor = new CapturingMockExecutor();
+      const localAgent = new AiChatAgent({ chatExecutor: executor });
+      await localAgent.getResponse({
+        meta: {},
+        messages: [{ role: "user", content: "go" }],
+        tools: [new BumpCounterTool()],
+      });
+      expect(executor.seenSystemPrompts).toEqual([undefined, undefined]);
+    });
+
+    it("re-serializes the template on the next iteration, reflecting tool template mutations", async () => {
+      // A tool that mutates context.systemPromptTemplate. The next
+      // iteration must serialize the new template, proving that template
+      // mutations are respected.
+      class HijackPromptTool extends BaseTool {
+        public name = "HijackPromptTool";
+        public description = "Overwrites context.systemPromptTemplate mid-run.";
+        public schema = z.object({});
+        public handler(
+          _params: z.infer<typeof this.schema>,
+          context: import("./types").ChatAgentContext,
+        ): string {
+          context.systemPromptTemplate = "HIJACKED";
+          return "hijacked";
+        }
+      }
+      class HijackMockExecutor implements ChatExecutor {
+        modelId = "mock-model-id";
+        modelProvider = "mock-model-provider";
+        public seen: (string | undefined)[] = [];
+        async execute(
+          input: ChatExecutorInput,
+        ): Promise<ChatAgentGetResponseOutput> {
+          this.seen.push(input.context.systemPrompt);
+          const last = input.messages[input.messages.length - 1];
+          if (last.role === "tool") {
+            const msg: ChatMessage = {
+              role: "assistant",
+              content: "done",
+            };
+            return { responseMessage: msg, responseMessages: [msg] };
+          }
+          const msg: ChatMessage = {
+            role: "tool_call",
+            toolCalls: [
+              {
+                function: { name: "HijackPromptTool", arguments: {} },
+                id: "hi-1",
+                type: "function",
+              },
+            ],
+          };
+          return { responseMessage: msg, responseMessages: [msg] };
+        }
+      }
+      const executor = new HijackMockExecutor();
+      const localAgent = new AiChatAgent({
+        chatExecutor: executor,
+        systemPromptTemplate: "Template prompt",
+      });
+      await localAgent.getResponse({
+        meta: {},
+        messages: [{ role: "user", content: "go" }],
+        tools: [new HijackPromptTool()],
+      });
+      expect(executor.seen).toEqual([
+        expect.stringContaining("Template prompt"),
+        expect.stringContaining("HIJACKED"),
+      ]);
+      // The second iteration should use the hijacked template.
+      expect(executor.seen[1]).toBe("HIJACKED");
+    });
+  });
 });

--- a/packages/core/src/ai-chat-agent.spec.ts
+++ b/packages/core/src/ai-chat-agent.spec.ts
@@ -336,10 +336,7 @@ describe("AiChatAgent", () => {
       ]);
     });
 
-    it("fires tool events but not ChatEnd on a returnDirect short-circuit", async () => {
-      // Documents current behavior: when a tool sets returnDirect=true the
-      // agent breaks out of the loop without emitting ChatEnd. If that ever
-      // changes, this assertion will need to be updated alongside it.
+    it("still emits ChatEnd on a returnDirect short-circuit", async () => {
       const producer = new EventProducer();
       const ordered = recordAllEvents(producer);
       const localAgent = new AiChatAgent({
@@ -351,9 +348,18 @@ describe("AiChatAgent", () => {
         messages: [{ role: "user", content: "ping" }],
         tools: [new PingPongTool()],
       });
-      expect(ordered).toContain(EventName.ToolStart);
-      expect(ordered).toContain(EventName.ToolEnd);
-      expect(ordered).not.toContain(EventName.ChatEnd);
+      expect(ordered).toEqual([
+        EventName.ChatStart,
+        EventName.ChatExecutorStart,
+        EventName.ChatRawRequest,
+        EventName.ChatRawResponse,
+        EventName.ChatExecutorEnd,
+        EventName.ToolsStart,
+        EventName.ToolStart,
+        EventName.ToolEnd,
+        EventName.ToolsEnd,
+        EventName.ChatEnd,
+      ]);
     });
   });
 });

--- a/packages/core/src/ai-chat-agent.ts
+++ b/packages/core/src/ai-chat-agent.ts
@@ -2,6 +2,7 @@ import {
   ChatExecutor,
   ChatAgentGetResponseInput,
   ChatAgentGetResponseOutput,
+  ChatMessage,
   ChatMessageTransformer,
   ChatAgent,
   MessageToolCall,
@@ -63,6 +64,7 @@ export class AiChatAgent implements ChatAgent {
     context.messages = messages;
     let started = false;
     const chatStartMs = Date.now();
+    let lastLlmResponseMessages: ChatMessage[] = [];
     do {
       const systemPrompt = this.systemPromptTemplate
         ? this.templateSerializer.serialize(this.systemPromptTemplate, meta)
@@ -98,6 +100,7 @@ export class AiChatAgent implements ChatAgent {
           context,
         );
       }
+      lastLlmResponseMessages = newResponseMessages;
       responseMessages.push(...newResponseMessages);
       this.eventProducer.emit(EventName.ChatExecutorEnd, {
         context,
@@ -135,15 +138,15 @@ export class AiChatAgent implements ChatAgent {
         messages = [...messages, ...newMessages];
       } else {
         doLoop = false;
-        this.eventProducer.emit(EventName.ChatEnd, {
-          context,
-          messages: response.responseMessages,
-          modelId: this.chatExecutor.modelId,
-          startTime: chatStartMs,
-          timeMs: Date.now() - chatStartMs,
-        });
       }
     } while (doLoop);
+    this.eventProducer.emit(EventName.ChatEnd, {
+      context,
+      messages: lastLlmResponseMessages,
+      modelId: this.chatExecutor.modelId,
+      startTime: chatStartMs,
+      timeMs: Date.now() - chatStartMs,
+    });
     for (const transformer of this.postRunTransformers) {
       responseMessages = await transformer.transform(responseMessages, context);
     }

--- a/packages/core/src/ai-chat-agent.ts
+++ b/packages/core/src/ai-chat-agent.ts
@@ -32,13 +32,14 @@ export class AiChatAgent implements ChatAgent {
     preToolCallTransformers?: ChatMessageTransformer[];
     postToolCallTransformers?: ChatMessageTransformer[];
     postRunTransformers?: ChatMessageTransformer[];
+    eventProducer?: EventProducer;
   }) {
     this.chatExecutor = options.chatExecutor;
     this.toolExecutor = options.toolExecutor || new ToolExecutor();
     this.preToolCallTransformers = options.preToolCallTransformers || [];
     this.postToolCallTransformers = options.postToolCallTransformers || [];
     this.postRunTransformers = options.postRunTransformers || [];
-    this.eventProducer = eventProducer;
+    this.eventProducer = options.eventProducer ?? eventProducer;
     this.systemPromptTemplate = options.systemPromptTemplate;
     this.templateSerializer =
       options.templateSerializer || new TemplateSerializer();
@@ -55,6 +56,7 @@ export class AiChatAgent implements ChatAgent {
       modelId: this.chatExecutor.modelId,
       messages,
       meta,
+      eventProducer: this.eventProducer,
     };
     context.runId = newRunId();
     context.modelId = this.chatExecutor.modelId;

--- a/packages/core/src/ai-chat-agent.ts
+++ b/packages/core/src/ai-chat-agent.ts
@@ -58,6 +58,8 @@ export class AiChatAgent implements ChatAgent {
       messages,
       meta,
       eventProducer: this.eventProducer,
+      systemPromptTemplate: this.systemPromptTemplate,
+      systemPrompt: undefined,
     };
     context.runId = newRunId();
     context.modelId = this.chatExecutor.modelId;
@@ -66,15 +68,19 @@ export class AiChatAgent implements ChatAgent {
     const chatStartMs = Date.now();
     let lastLlmResponseMessages: ChatMessage[] = [];
     do {
-      const systemPrompt = this.systemPromptTemplate
-        ? this.templateSerializer.serialize(this.systemPromptTemplate, meta)
+      // Synthesize the system prompt from the template and meta on each iteration
+      context.systemPrompt = context.systemPromptTemplate
+        ? this.templateSerializer.serialize(
+            context.systemPromptTemplate,
+            context.meta,
+          )
         : undefined;
       if (!started) {
         this.eventProducer.emit(EventName.ChatStart, {
           context,
           startTime: chatStartMs,
           messages,
-          systemPrompt,
+          systemPrompt: context.systemPrompt,
           modelId: this.chatExecutor.modelId,
         });
         started = true;
@@ -84,13 +90,12 @@ export class AiChatAgent implements ChatAgent {
         context,
         startTime: chatExecutorStartMs,
         messages,
-        systemPrompt,
+        systemPrompt: context.systemPrompt,
         modelId: this.chatExecutor.modelId,
       });
       const response = await this.chatExecutor.execute({
         messages,
         tools,
-        systemPrompt,
         context,
       });
       let newResponseMessages = response.responseMessages;

--- a/packages/core/src/event-producer.ts
+++ b/packages/core/src/event-producer.ts
@@ -74,6 +74,16 @@ export interface EventChatRawResponse extends ChatEndEvent {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   response: any;
 }
+export interface EventToolProgress extends ChatEvent {
+  message: string;
+}
+export type LogLevel = "error" | "warn" | "info" | "debug" | "verbose";
+export interface EventLog extends ChatEvent {
+  message: string;
+  level: LogLevel;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  meta: Record<string, any>;
+}
 
 /**
  * Events that can be emitted by the event producer and can be subscribed to by the event subscriber
@@ -99,6 +109,10 @@ export enum EventName {
   ChatRawRequest = "chat:raw:request",
   /** Emitted by a chat executor to show the raw API response. Shape will vary by executor */
   ChatRawResponse = "chat:raw:response",
+  /** Emitted by a tool while it is running to surface progress updates to subscribers */
+  ToolProgress = "tool:progress",
+  /** General-purpose structured log line emitted from anywhere with access to the context */
+  Log = "log",
 }
 /**
  * Map of event names to event types
@@ -134,6 +148,8 @@ export interface EventTypeMap {
   [EventName.ChatExecutorEnd]: EventChatExecutorEnd;
   [EventName.ChatRawRequest]: EventChatRawRequest;
   [EventName.ChatRawResponse]: EventChatRawResponse;
+  [EventName.ToolProgress]: EventToolProgress;
+  [EventName.Log]: EventLog;
 }
 
 export class EventProducer {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,4 +31,7 @@ export {
   EventChatStart,
   EventChatExecutorEnd,
   EventToolEnd,
+  EventToolProgress,
+  EventLog,
+  LogLevel,
 } from "./event-producer";

--- a/packages/core/src/tool-executor.ts
+++ b/packages/core/src/tool-executor.ts
@@ -1,15 +1,11 @@
 import { ITool } from "./base-tool";
-import { EventName, eventProducer, EventProducer } from "./event-producer";
+import { EventName } from "./event-producer";
 import { ChatAgentContext, MessageTool, MessageToolCall } from "./types";
 
 /**
  * All Agents should use this class to execute tools
  */
 export class ToolExecutor {
-  private eventProducer: EventProducer;
-  constructor() {
-    this.eventProducer = eventProducer;
-  }
   /**
    * Give a tool call message, which may contain multiple tool calls, execute each tool call and return the results
    */
@@ -32,7 +28,7 @@ export class ToolExecutor {
           };
         }
         const toolStartMs = Date.now();
-        this.eventProducer.emit(EventName.ToolStart, {
+        context.eventProducer.emit(EventName.ToolStart, {
           context,
           startTime: toolStartMs,
           toolCall: toolCallMessage,
@@ -56,7 +52,7 @@ export class ToolExecutor {
             status: "error" as const,
             returnDirect: false,
           }));
-        this.eventProducer.emit(EventName.ToolEnd, {
+        context.eventProducer.emit(EventName.ToolEnd, {
           context,
           startTime: toolStartMs,
           timeMs: Date.now() - toolStartMs,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,6 +7,7 @@ These types should be suitable for storing history with a clear idea of what hap
 */
 
 import type { ITool } from "./base-tool";
+import type { EventProducer } from "./event-producer";
 
 /**
  * A system message in the chat
@@ -104,6 +105,7 @@ export interface ChatAgentContext {
   modelId: string;
   messages: ChatMessage[];
   meta: ChatAgentContentMeta;
+  eventProducer: EventProducer;
 }
 export interface ChatAgentGetResponseInput {
   messages: ChatMessage[];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -106,6 +106,18 @@ export interface ChatAgentContext {
   messages: ChatMessage[];
   meta: ChatAgentContentMeta;
   eventProducer: EventProducer;
+  /**
+   * The system prompt template that can be mutated by tools to affect
+   * subsequent loop iterations. The agent serializes this template on every
+   * iteration using the current `meta` values.
+   */
+  systemPromptTemplate?: string;
+  /**
+   * The synthesized system prompt for the current loop iteration, serialized
+   * from `systemPromptTemplate` and `meta`. This is regenerated each iteration
+   * by the agent. Tools should mutate `systemPromptTemplate` instead.
+   */
+  systemPrompt?: string;
 }
 export interface ChatAgentGetResponseInput {
   messages: ChatMessage[];
@@ -130,7 +142,6 @@ export interface ChatAgent {
 export interface ChatExecutorInput {
   messages: ChatMessage[];
   tools?: ITool[];
-  systemPrompt?: string;
   context: ChatAgentContext;
 }
 export interface ChatExecutor {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node", "jest"]
   },
   "include": ["./src/**/*.ts"]
 }

--- a/packages/datadog/src/llm-spans-api.ts
+++ b/packages/datadog/src/llm-spans-api.ts
@@ -50,13 +50,13 @@ interface Metrics {
 }
 interface Meta {
   kind:
-  | "agent"
-  | "workflow"
-  | "llm"
-  | "tool"
-  | "task"
-  | "embedding"
-  | "retrieval";
+    | "agent"
+    | "workflow"
+    | "llm"
+    | "tool"
+    | "task"
+    | "embedding"
+    | "retrieval";
   error?: DDError;
   input: IO;
   output: IO;
@@ -194,6 +194,7 @@ export class LlmSpansApi {
         {},
       )
       .catch((err) => {
+        // eslint-disable-next-line no-console
         console.error("Failed to send spans to Datadog", {
           error: err,
           requestErrors: err.response.data.errors,

--- a/packages/examples/src/e2e/e2e.spec.ts
+++ b/packages/examples/src/e2e/e2e.spec.ts
@@ -11,11 +11,19 @@ interface ChatMessage {
   toolCalls?: unknown[];
 }
 
+interface CapturedEvent {
+  name: "tool:progress" | "log";
+  message: string;
+  level?: "error" | "warn" | "info" | "debug" | "verbose";
+  meta?: Record<string, unknown>;
+}
+
 interface ChatResponse {
   response: string;
   agent: string;
   messages: ChatMessage[];
   usage?: { inputTokens: number; outputTokens: number; totalTokens: number };
+  events?: CapturedEvent[];
 }
 
 async function chat(body: {
@@ -133,6 +141,32 @@ describe("Tool Calling", () => {
       agent: "claude",
     });
     expect(data.response).toMatch(/\b2\b/);
+  });
+
+  test("CountLettersTool — emits ToolProgress and Log events", async () => {
+    const { data } = await chat({
+      message: "How many L's are in the word 'hello'?",
+      agent: "claude",
+    });
+    const events = data.events ?? [];
+    const progress = events.filter((e) => e.name === "tool:progress");
+    const logs = events.filter((e) => e.name === "log");
+
+    expect(progress.length).toBeGreaterThanOrEqual(2);
+    expect(progress.map((p) => p.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Scanning"),
+        expect.stringContaining("Found"),
+      ]),
+    );
+
+    expect(logs.length).toBeGreaterThanOrEqual(2);
+    expect(logs.map((l) => l.level)).toEqual(
+      expect.arrayContaining(["info", "debug"]),
+    );
+    const finishedLog = logs.find((l) => l.message.includes("finished"));
+    expect(finishedLog).toBeDefined();
+    expect(finishedLog?.meta).toMatchObject({ word: "hello", letter: "l" });
   });
 
   test("CurrentTimeTool — returns a time value", async () => {

--- a/packages/examples/src/e2e/e2e.spec.ts
+++ b/packages/examples/src/e2e/e2e.spec.ts
@@ -36,13 +36,12 @@ async function chat(body: {
   return { status: res.status, data };
 }
 
-async function assertJudge(
-  response: string,
-  criteria: string,
-): Promise<void> {
+async function assertJudge(response: string, criteria: string): Promise<void> {
   const result = await judge(response, criteria);
   if (!result.pass) {
-    throw new Error(`LLM judge failed — ${result.reason}\n\nResponse was:\n${response}`);
+    throw new Error(
+      `LLM judge failed — ${result.reason}\n\nResponse was:\n${response}`,
+    );
   }
 }
 
@@ -61,22 +60,34 @@ describe("Per-Module Response", () => {
   const CRITERIA = "The response is a greeting from an AI assistant";
 
   test("charlie-bedrock via claude", async () => {
-    const { data } = await chat({ message: "Say hello and tell me your name", agent: "claude" });
+    const { data } = await chat({
+      message: "Say hello and tell me your name",
+      agent: "claude",
+    });
     await assertJudge(data.response, CRITERIA);
   });
 
   test("charlie-openai via gpt4o", async () => {
-    const { data } = await chat({ message: "Say hello and tell me your name", agent: "gpt4o" });
+    const { data } = await chat({
+      message: "Say hello and tell me your name",
+      agent: "gpt4o",
+    });
     await assertJudge(data.response, CRITERIA);
   });
 
   test("charlie-google via gemini", async () => {
-    const { data } = await chat({ message: "Say hello and tell me your name", agent: "gemini" });
+    const { data } = await chat({
+      message: "Say hello and tell me your name",
+      agent: "gemini",
+    });
     await assertJudge(data.response, CRITERIA);
   });
 
   test("charlie-openai via GrokExecutor (grok)", async () => {
-    const { data } = await chat({ message: "Say hello and tell me your name", agent: "grok" });
+    const { data } = await chat({
+      message: "Say hello and tell me your name",
+      agent: "grok",
+    });
     await assertJudge(data.response, CRITERIA);
   });
 });
@@ -109,7 +120,10 @@ describe("Bedrock Model Smoke Tests", () => {
 // ---------------------------------------------------------------------------
 describe("Tool Calling", () => {
   test("CalculatorTool — computes result and returns 105", async () => {
-    const { data } = await chat({ message: "What is 15 multiplied by 7?", agent: "claude" });
+    const { data } = await chat({
+      message: "What is 15 multiplied by 7?",
+      agent: "claude",
+    });
     expect(data.response).toContain("105");
   });
 
@@ -126,7 +140,10 @@ describe("Tool Calling", () => {
       message: "What time is it right now?",
       agent: "claude",
     });
-    await assertJudge(data.response, "The response mentions a specific time or date");
+    await assertJudge(
+      data.response,
+      "The response mentions a specific time or date",
+    );
   });
 
   test("DirectBirthdayTool — returnDirect stops the agent loop", async () => {
@@ -138,7 +155,10 @@ describe("Tool Calling", () => {
     const toolIdx = data.messages.map((m) => m.role).lastIndexOf("tool");
     const afterTool = data.messages.slice(toolIdx + 1);
     expect(afterTool.some((m) => m.role === "tool_call")).toBe(false);
-    await assertJudge(data.response, "The response confirms a birthday was set");
+    await assertJudge(
+      data.response,
+      "The response confirms a birthday was set",
+    );
   });
 
   test("DeleteAccountTool — asks for confirmation when not certain", async () => {
@@ -162,7 +182,10 @@ describe("Tool Calling", () => {
       agent: "claude",
       messages: turn1.data.messages,
     });
-    await assertJudge(data.response, "The response confirms the account has been deleted");
+    await assertJudge(
+      data.response,
+      "The response confirms the account has been deleted",
+    );
   });
 
   test("CalculatorTool via Titan (InlineToolCallParser)", async () => {

--- a/packages/examples/src/e2e/helpers/judge.ts
+++ b/packages/examples/src/e2e/helpers/judge.ts
@@ -11,7 +11,7 @@ export async function judge(
 ): Promise<JudgeResult> {
   const message = [
     "YOUR TASK: Evaluate a response against criteria.",
-    'Return ONLY a JSON object — no explanation, no emoji, no surrounding text.',
+    "Return ONLY a JSON object — no explanation, no emoji, no surrounding text.",
     'Format: {"pass": true, "reason": "..."} or {"pass": false, "reason": "..."}',
     "",
     `Criteria: ${criteria}`,
@@ -55,5 +55,8 @@ function parseJudgeResponse(text: string): JudgeResult {
     };
   }
 
-  return { pass: false, reason: `Could not parse judge response: ${text.slice(0, 200)}` };
+  return {
+    pass: false,
+    reason: `Could not parse judge response: ${text.slice(0, 200)}`,
+  };
 }

--- a/packages/examples/src/repl/index.ts
+++ b/packages/examples/src/repl/index.ts
@@ -5,9 +5,10 @@ import {
   ChatAgent,
   ChatMessage,
   EventName,
+  EventProducer,
+  EventSubscriber,
   MessageUser,
   ToolAssistantFilter,
-  events,
 } from "@jbcbdse/charlie-core";
 import {
   BedrockChatExecutor,
@@ -26,16 +27,19 @@ import { DirectBirthdayTool } from "../tools/direct-birthday.tool";
 import { DeleteAccountTool } from "../tools/delete-account.tool";
 dotenv.config({ path: "../../.env" });
 
-events.on(EventName.ToolStart, (data) => {
+const appEventProducer = new EventProducer();
+const appEvents = new EventSubscriber(appEventProducer);
+
+appEvents.on(EventName.ToolStart, (data) => {
   // console.debug(EventName.ChatRawRequest, JSON.stringify(data, null, 2));
   console.dir(data.toolCall.toolCalls, { depth: null });
 });
-events.on(EventName.ToolsEnd, (data) => {
+appEvents.on(EventName.ToolsEnd, (data) => {
   data.toolMessages.forEach((toolMessage, index) => {
     console.log(`[Tool result ${index + 1}] ${toolMessage.content}`);
   });
 });
-events.on(EventName.ChatEnd, (data) => {
+appEvents.on(EventName.ChatEnd, (data) => {
   console.dir(data.messages, { depth: null });
   console.log(data.modelId, "complete");
 });
@@ -46,7 +50,7 @@ if (process.env.DD_API_KEY) {
       service: "charlie",
       env: "dev",
     },
-  }).listen(events);
+  }).listen(appEvents);
 }
 // events.on(EventName.ChatRawResponse, (data) => {
 //   // console.debug(EventName.ChatRawResponse, JSON.stringify(data, null, 2));
@@ -79,6 +83,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
     }),
     systemPromptTemplate: promptTemplate,
     preToolCallTransformers: [toolAssistantFilter],
+    eventProducer: appEventProducer,
   }),
   mistral: new AiChatAgent({
     chatExecutor: new BedrockChatExecutor({
@@ -86,6 +91,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
     }),
     systemPromptTemplate: promptTemplate,
     preToolCallTransformers: [toolAssistantFilter],
+    eventProducer: appEventProducer,
   }),
   commandr: new AiChatAgent({
     chatExecutor: new BedrockChatExecutor({
@@ -93,6 +99,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
     }),
     systemPromptTemplate: promptTemplate,
     preToolCallTransformers: [toolAssistantFilter],
+    eventProducer: appEventProducer,
   }),
   llama: new AiChatAgent({
     chatExecutor: new BedrockChatExecutor({
@@ -100,6 +107,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
     }),
     systemPromptTemplate: promptTemplate,
     preToolCallTransformers: [toolAssistantFilter],
+    eventProducer: appEventProducer,
   }),
   "jamba-large": new AiChatAgent({
     chatExecutor: new BedrockChatExecutor({
@@ -107,6 +115,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
     }),
     systemPromptTemplate: promptTemplate,
     preToolCallTransformers: [toolAssistantFilter],
+    eventProducer: appEventProducer,
   }),
   nova: new AiChatAgent({
     chatExecutor: new BedrockChatExecutor({
@@ -114,6 +123,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
     }),
     systemPromptTemplate: promptTemplate,
     preToolCallTransformers: [toolAssistantFilter],
+    eventProducer: appEventProducer,
   }),
   titan: new AiChatAgent({
     chatExecutor: new BedrockChatExecutor({
@@ -122,6 +132,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
     }),
     systemPromptTemplate: promptTemplate,
     preToolCallTransformers: [inlineToolCallParser, toolAssistantFilter],
+    eventProducer: appEventProducer,
   }),
   gpt4o: new AiChatAgent({
     chatExecutor: new OpenAiChatExecutor({
@@ -129,6 +140,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
       apiKey: process.env.OPENAI_API_KEY!,
     }),
     systemPromptTemplate: promptTemplate,
+    eventProducer: appEventProducer,
   }),
   grok: new AiChatAgent({
     chatExecutor: new GrokExecutor({
@@ -136,6 +148,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
       apiKey: process.env.XAI_API_KEY!,
     }),
     systemPromptTemplate: promptTemplate,
+    eventProducer: appEventProducer,
   }),
   gemini: new AiChatAgent({
     chatExecutor: new GeminiExecutor({
@@ -143,6 +156,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
       apiKey: process.env.GOOGLE_API_KEY!,
     }),
     systemPromptTemplate: promptTemplate,
+    eventProducer: appEventProducer,
   }),
 };
 const tools = [

--- a/packages/examples/src/repl/index.ts
+++ b/packages/examples/src/repl/index.ts
@@ -43,6 +43,12 @@ appEvents.on(EventName.ChatEnd, (data) => {
   console.dir(data.messages, { depth: null });
   console.log(data.modelId, "complete");
 });
+appEvents.on(EventName.ToolProgress, (data) => {
+  console.log(`[progress] ${data.message}`);
+});
+appEvents.on(EventName.Log, (data) => {
+  console.log(`[${data.level}] ${data.message}`, data.meta);
+});
 if (process.env.DD_API_KEY) {
   new LlmSpansApi({
     apiKey: process.env.DD_API_KEY!,

--- a/packages/examples/src/server/index.ts
+++ b/packages/examples/src/server/index.ts
@@ -145,7 +145,7 @@ const app = express();
 app.use(express.json());
 
 app.get("/agents", agentsHandler(availableAgents));
-app.post("/chat", chatHandler(agents, availableAgents, tools));
+app.post("/chat", chatHandler(agents, availableAgents, tools, appEvents));
 
 const PORT = process.env.PORT || 3456;
 app.listen(PORT, () => {

--- a/packages/examples/src/server/index.ts
+++ b/packages/examples/src/server/index.ts
@@ -4,8 +4,9 @@ import express from "express";
 import {
   AiChatAgent,
   ChatAgent,
+  EventProducer,
+  EventSubscriber,
   ToolAssistantFilter,
-  events,
 } from "@jbcbdse/charlie-core";
 import {
   BedrockChatExecutor,
@@ -24,11 +25,14 @@ import { AvailableAgent, agentsHandler } from "./routes/agents";
 import { chatHandler } from "./routes/chat";
 dotenv.config({ path: "../../.env" });
 
+const appEventProducer = new EventProducer();
+const appEvents = new EventSubscriber(appEventProducer);
+
 if (process.env.DD_API_KEY) {
   new LlmSpansApi({
     apiKey: process.env.DD_API_KEY!,
     tags: { service: "charlie", env: "dev" },
-  }).listen(events);
+  }).listen(appEvents);
 }
 
 const promptTemplate = [
@@ -50,6 +54,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
     }),
     systemPromptTemplate: promptTemplate,
     preToolCallTransformers: [toolAssistantFilter],
+    eventProducer: appEventProducer,
   }),
   mistral: new AiChatAgent({
     chatExecutor: new BedrockChatExecutor({
@@ -57,6 +62,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
     }),
     systemPromptTemplate: promptTemplate,
     preToolCallTransformers: [toolAssistantFilter],
+    eventProducer: appEventProducer,
   }),
   commandr: new AiChatAgent({
     chatExecutor: new BedrockChatExecutor({
@@ -64,6 +70,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
     }),
     systemPromptTemplate: promptTemplate,
     preToolCallTransformers: [toolAssistantFilter],
+    eventProducer: appEventProducer,
   }),
   llama: new AiChatAgent({
     chatExecutor: new BedrockChatExecutor({
@@ -71,6 +78,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
     }),
     systemPromptTemplate: promptTemplate,
     preToolCallTransformers: [toolAssistantFilter],
+    eventProducer: appEventProducer,
   }),
   "jamba-large": new AiChatAgent({
     chatExecutor: new BedrockChatExecutor({
@@ -78,6 +86,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
     }),
     systemPromptTemplate: promptTemplate,
     preToolCallTransformers: [toolAssistantFilter],
+    eventProducer: appEventProducer,
   }),
   nova: new AiChatAgent({
     chatExecutor: new BedrockChatExecutor({
@@ -85,6 +94,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
     }),
     systemPromptTemplate: promptTemplate,
     preToolCallTransformers: [toolAssistantFilter],
+    eventProducer: appEventProducer,
   }),
   titan: new AiChatAgent({
     chatExecutor: new BedrockChatExecutor({
@@ -93,6 +103,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
     }),
     systemPromptTemplate: promptTemplate,
     preToolCallTransformers: [inlineToolCallParser, toolAssistantFilter],
+    eventProducer: appEventProducer,
   }),
   gpt4o: new AiChatAgent({
     chatExecutor: new OpenAiChatExecutor({
@@ -100,6 +111,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
       apiKey: process.env.OPENAI_API_KEY!,
     }),
     systemPromptTemplate: promptTemplate,
+    eventProducer: appEventProducer,
   }),
   grok: new AiChatAgent({
     chatExecutor: new GrokExecutor({
@@ -107,6 +119,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
       apiKey: process.env.XAI_API_KEY!,
     }),
     systemPromptTemplate: promptTemplate,
+    eventProducer: appEventProducer,
   }),
   gemini: new AiChatAgent({
     chatExecutor: new GeminiExecutor({
@@ -114,6 +127,7 @@ const agents: Record<AvailableAgent, ChatAgent> = {
       apiKey: process.env.GOOGLE_API_KEY!,
     }),
     systemPromptTemplate: promptTemplate,
+    eventProducer: appEventProducer,
   }),
 };
 

--- a/packages/examples/src/server/routes/chat.ts
+++ b/packages/examples/src/server/routes/chat.ts
@@ -3,9 +3,14 @@ import { Request, Response } from "express";
 import {
   ChatAgent,
   ChatMessage,
+  EventLog,
+  EventName,
+  EventSubscriber,
+  EventToolProgress,
   ITool,
   MessageUser,
 } from "@jbcbdse/charlie-core";
+import { randomUUID } from "node:crypto";
 import { AvailableAgent } from "./agents";
 
 interface ChatRequest {
@@ -15,10 +20,18 @@ interface ChatRequest {
   user?: Record<string, string>;
 }
 
+interface CapturedEvent {
+  name: EventName.ToolProgress | EventName.Log;
+  message: string;
+  level?: EventLog["level"];
+  meta?: EventLog["meta"];
+}
+
 export function chatHandler(
   agents: Record<AvailableAgent, ChatAgent>,
   availableAgents: AvailableAgent[],
   tools: ITool[],
+  appEvents: EventSubscriber,
 ) {
   return async (req: Request, res: Response) => {
     const {
@@ -42,11 +55,38 @@ export function chatHandler(
     const userMessage: MessageUser = { role: "user", content: message };
     const history: ChatMessage[] = [...messages, userMessage];
 
+    // Tag every event from this request via meta.requestId so we can pull our
+    // own events out of the shared producer without picking up concurrent
+    // requests' events.
+    const requestId = randomUUID();
+    const captured: CapturedEvent[] = [];
+    const onProgress = (event: EventToolProgress): void => {
+      if (event.context.meta.requestId === requestId) {
+        captured.push({
+          name: EventName.ToolProgress,
+          message: event.message,
+        });
+      }
+    };
+    const onLog = (event: EventLog): void => {
+      if (event.context.meta.requestId === requestId) {
+        captured.push({
+          name: EventName.Log,
+          message: event.message,
+          level: event.level,
+          meta: event.meta,
+        });
+      }
+    };
+    appEvents.on(EventName.ToolProgress, onProgress);
+    appEvents.on(EventName.Log, onLog);
+
     try {
       const result = await agents[agent].getResponse({
         messages: history,
         tools,
         meta: {
+          requestId,
           user: {
             first_name: "Jonathan",
             last_name: "Barnett",
@@ -68,11 +108,15 @@ export function chatHandler(
         agent,
         messages: updatedMessages,
         usage: result.usage,
+        events: captured,
       });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       console.error("Chat error:", err);
       res.status(500).json({ error: message });
+    } finally {
+      appEvents.off(EventName.ToolProgress, onProgress);
+      appEvents.off(EventName.Log, onLog);
     }
   };
 }

--- a/packages/examples/src/server/routes/chat.ts
+++ b/packages/examples/src/server/routes/chat.ts
@@ -1,6 +1,11 @@
 /* eslint-disable no-console */
 import { Request, Response } from "express";
-import { ChatAgent, ChatMessage, ITool, MessageUser } from "@jbcbdse/charlie-core";
+import {
+  ChatAgent,
+  ChatMessage,
+  ITool,
+  MessageUser,
+} from "@jbcbdse/charlie-core";
 import { AvailableAgent } from "./agents";
 
 interface ChatRequest {
@@ -16,14 +21,21 @@ export function chatHandler(
   tools: ITool[],
 ) {
   return async (req: Request, res: Response) => {
-    const { message, agent = "claude", messages = [], user = {} }: ChatRequest = req.body;
+    const {
+      message,
+      agent = "claude",
+      messages = [],
+      user = {},
+    }: ChatRequest = req.body;
 
     if (!message) {
       res.status(400).json({ error: "message is required" });
       return;
     }
     if (!availableAgents.includes(agent)) {
-      res.status(400).json({ error: `unknown agent: ${agent}. Available: ${availableAgents.join(", ")}` });
+      res.status(400).json({
+        error: `unknown agent: ${agent}. Available: ${availableAgents.join(", ")}`,
+      });
       return;
     }
 
@@ -35,7 +47,12 @@ export function chatHandler(
         messages: history,
         tools,
         meta: {
-          user: { first_name: "Jonathan", last_name: "Barnett", preferred_name: "Jon", ...user },
+          user: {
+            first_name: "Jonathan",
+            last_name: "Barnett",
+            preferred_name: "Jon",
+            ...user,
+          },
           availableAgents,
         },
       });

--- a/packages/examples/src/tools/letter-count.tool.ts
+++ b/packages/examples/src/tools/letter-count.tool.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { BaseTool } from "@jbcbdse/charlie-core";
+import { BaseTool, ChatAgentContext, EventName } from "@jbcbdse/charlie-core";
 
 export class CountLettersTool extends BaseTool {
   public name = CountLettersTool.name;
@@ -13,8 +13,31 @@ export class CountLettersTool extends BaseTool {
       .string()
       .describe("The letter you want to count in the word or phrase."),
   });
-  public handler({ word, letter }: z.infer<typeof this.schema>): string {
+  public handler(
+    { word, letter }: z.infer<typeof this.schema>,
+    context: ChatAgentContext,
+  ): string {
+    context.eventProducer.emit(EventName.Log, {
+      context,
+      level: "info",
+      message: "CountLettersTool starting",
+      meta: { word, letter },
+    });
+    context.eventProducer.emit(EventName.ToolProgress, {
+      context,
+      message: `Scanning "${word}" for "${letter}"`,
+    });
     const count = word.toLowerCase().split(letter.toLowerCase()).length - 1;
+    context.eventProducer.emit(EventName.ToolProgress, {
+      context,
+      message: `Found ${count} match(es)`,
+    });
+    context.eventProducer.emit(EventName.Log, {
+      context,
+      level: "debug",
+      message: "CountLettersTool finished",
+      meta: { word, letter, count },
+    });
     return `There are ${count} "${letter.toUpperCase()}"s in "${word}".`;
   }
 }

--- a/packages/google/src/gemini-executor.ts
+++ b/packages/google/src/gemini-executor.ts
@@ -2,7 +2,6 @@ import {
   ChatExecutor,
   ChatExecutorInput,
   EventName,
-  eventProducer,
   ChatAgentGetResponseOutput,
 } from "@jbcbdse/charlie-core";
 import {
@@ -43,13 +42,13 @@ export class GeminiExecutor implements ChatExecutor {
       systemInstruction: systemPrompt,
     };
     const startMs = Date.now();
-    eventProducer.emit(EventName.ChatRawRequest, {
+    context.eventProducer.emit(EventName.ChatRawRequest, {
       context,
       modelId: this.modelId,
       request: req,
     });
     const response = await this.model.generateContent(req);
-    eventProducer.emit(EventName.ChatRawResponse, {
+    context.eventProducer.emit(EventName.ChatRawResponse, {
       context,
       modelId: this.modelId,
       response,

--- a/packages/google/src/gemini-executor.ts
+++ b/packages/google/src/gemini-executor.ts
@@ -35,11 +35,11 @@ export class GeminiExecutor implements ChatExecutor {
   public async execute(
     input: ChatExecutorInput,
   ): Promise<ChatAgentGetResponseOutput> {
-    const { context, messages, systemPrompt, tools } = input;
+    const { context, messages, tools } = input;
     const req: GenerateContentRequest = {
       contents: this.messageConverter.toContentObjects(messages),
       tools: tools ? await this.toolConverter.toGeminiTools(tools) : [],
-      systemInstruction: systemPrompt,
+      systemInstruction: context.systemPrompt,
     };
     const startMs = Date.now();
     context.eventProducer.emit(EventName.ChatRawRequest, {

--- a/packages/openai/src/openai-chat-executor.ts
+++ b/packages/openai/src/openai-chat-executor.ts
@@ -7,8 +7,6 @@ import {
   ChatExecutorInput,
   TemplateSerializer,
   EventName,
-  eventProducer,
-  EventProducer,
 } from "@jbcbdse/charlie-core";
 
 export interface OpenAiChatExecutorOptions {
@@ -19,13 +17,11 @@ export interface OpenAiChatExecutorOptions {
   apiKey?: string;
   baseURL?: string;
   dangerouslyAllowBrowser?: boolean;
-  eventProducer?: EventProducer;
   maxRetries?: number;
   timeout?: number;
 }
 export class OpenAiChatExecutor implements ChatExecutor {
   private openAiClient: OpenAI;
-  private eventProducer: EventProducer;
   public modelProvider: string;
   public modelId: string;
   constructor(private options: OpenAiChatExecutorOptions) {
@@ -41,7 +37,6 @@ export class OpenAiChatExecutor implements ChatExecutor {
         maxRetries: options.maxRetries || undefined,
         timeout: options.timeout || undefined,
       });
-    this.eventProducer = options.eventProducer ?? eventProducer;
   }
   public async execute({
     messages,
@@ -71,13 +66,13 @@ export class OpenAiChatExecutor implements ChatExecutor {
         })),
     };
     const chatExecutorStartMs = Date.now();
-    this.eventProducer.emit(EventName.ChatRawRequest, {
+    context.eventProducer.emit(EventName.ChatRawRequest, {
       context,
       request,
       modelId: this.modelId,
     });
     const data = await this.openAiClient.chat.completions.create(request);
-    this.eventProducer.emit(EventName.ChatRawResponse, {
+    context.eventProducer.emit(EventName.ChatRawResponse, {
       context,
       response: data,
       modelId: this.modelId,

--- a/packages/openai/src/openai-chat-executor.ts
+++ b/packages/openai/src/openai-chat-executor.ts
@@ -41,14 +41,13 @@ export class OpenAiChatExecutor implements ChatExecutor {
   public async execute({
     messages,
     tools,
-    systemPrompt,
     context,
   }: ChatExecutorInput): Promise<ChatAgentGetResponseOutput> {
     const openAiMessages = this.toOpenAiMessages(messages);
-    if (systemPrompt) {
+    if (context.systemPrompt) {
       openAiMessages.unshift({
         role: "system",
-        content: systemPrompt,
+        content: context.systemPrompt,
       });
     }
     const request: OpenAiCompletionsRequest = {


### PR DESCRIPTION
## Summary

- `AiChatAgent` now accepts an optional `eventProducer` in its constructor (defaults to the global singleton) and attaches it to `ChatAgentContext`. Multiple agents in the same process can finally have isolated event streams.
- `ToolExecutor`, `OpenAiChatExecutor`, `BedrockChatExecutor`, and `GeminiExecutor` all emit through `context.eventProducer` instead of holding their own reference. The `eventProducer` constructor option is **removed** from `OpenAiChatExecutorOptions` and the Bedrock options.
- Tools transparently get access via `context.eventProducer` if they ever need to emit.
- REPL and HTTP server examples build their own `EventProducer` + `EventSubscriber` and wire them into every `AiChatAgent`, demonstrating the new DI path end-to-end (including `LlmSpansApi.listen(...)`).
- New `eventProducer injection` spec block covers default-to-global, custom-producer routing, context injection, full tool-call event ordering, and listener isolation against the global producer.

The second commit applies pre-existing prettier auto-fixes and one `eslint-disable-next-line` for the Datadog catch handler so `npm run lint --workspaces` exits clean with zero warnings (those errors blocked the lint gate on master independently of this refactor).

## Breaking changes

- `OpenAiChatExecutorOptions.eventProducer` — removed. Pass the producer to `AiChatAgent` instead.
- `BedrockChatExecutor` constructor option `eventProducer` — removed. Same migration.
- `ChatAgentContext.eventProducer` is now a required field. Code that constructs a context directly must populate it.
- `new ToolExecutor()` still works at the call site, but the class no longer holds an `eventProducer`; it reads from the context every time.

## Test plan

- [x] `npm run lint --workspaces` — 0 errors, 0 warnings.
- [x] `npm run test --workspace=@jbcbdse/charlie-core` — 8/8 passing, including 5 new event-injection tests.
- [x] `npm run build --workspaces` — all packages compile, including the type-only `EventProducer` import added to `types.ts` to avoid a runtime circular dep.
- [x] e2e: 19/20 e2e tests pass; the one failure (`charlie-openai via gpt4o`) is an LLM-judge non-determinism that reproduces on master with no changes.
- [x] `charlie-datadog`'s "no tests found" exit-1 also pre-existed on master and is unrelated.